### PR TITLE
Bug Fix App Crash From Null Return

### DIFF
--- a/app/src/main/java/com/redcoracle/episodes/tvdb/Client.java
+++ b/app/src/main/java/com/redcoracle/episodes/tvdb/Client.java
@@ -55,7 +55,7 @@ public class Client
 			}
 		} catch (IOException e) {
 			Log.w(TAG, e);
-			return null;
+			return new LinkedList<>();
 		}
 	}
 


### PR DESCRIPTION
Modifies the behaviour of searchShows() to instead return an empty list if an IO Exception occurs. This is preferable to returning null to avoid NullPointerExceptions and app crashing. This can occur if a query is made when the app starts without an internet connection.