### PR TITLE
Add version information to AboutActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,14 @@
 apply plugin: 'com.android.application'
 
+def getCommitId = { ->
+    def gitOutput = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        standardOutput = gitOutput
+    }
+    return gitOutput.toString().trim()
+}
+
 android {
     compileSdkVersion 30
     buildToolsVersion "29.0.3"
@@ -9,6 +18,7 @@ android {
         versionCode 16
         versionName "0.13.3"
         buildConfigField "String", "TVDB_KEY", "\"E457AE7B767BC9F4\""
+        buildConfigField "String", "GIT_COMMIT_ID", "\"${getCommitId()}\""
     }
     flavorDimensions "flavor"
     productFlavors {

--- a/app/src/main/java/com/redcoracle/episodes/AboutActivity.java
+++ b/app/src/main/java/com/redcoracle/episodes/AboutActivity.java
@@ -19,6 +19,7 @@ package com.redcoracle.episodes;
 
 import android.os.Bundle;
 import android.view.MenuItem;
+import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -31,6 +32,13 @@ public class AboutActivity
 
 		setContentView(R.layout.about_activity);
 		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+		TextView versionInfoView = findViewById(R.id.version_view);
+		versionInfoView.setText(
+				getBaseContext().getString(
+						R.string.version,
+						BuildConfig.VERSION_NAME,
+						BuildConfig.GIT_COMMIT_ID));
 	}
 
 	@Override

--- a/app/src/main/res/layout/about_activity.xml
+++ b/app/src/main/res/layout/about_activity.xml
@@ -37,4 +37,11 @@
       android:text="@string/about_tvdb"
       android:textAppearance="?android:attr/textAppearanceSmall"
       android:padding="4dp" />
+  <TextView
+      android:id="@+id/version_view"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:text="@string/version"
+      android:textAppearance="?android:attr/textAppearanceSmall"
+      android:padding="4dp" />
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,4 +62,5 @@
   <string name="channel_description">Notification when syncing shows</string>
   <string name="pref_auto_refresh_category">Auto-refresh series</string>
   <string name="pref_interface_category">Interface</string>
+  <string name="version">Version %s (Commit %s)</string>
 </resources>


### PR DESCRIPTION
Hi @red-coracle,

for easier traceability of debug builds and builds from app stores like F-Droid, I think it would be nice to include the version number in the About activity. I implemented the suggestion here. What do you think about it?

Best
André
