### PR TITLE
Fix URL encoding for thetvdb search queries

### DIFF
--- a/app/src/main/java/com/redcoracle/episodes/tvdb/Client.java
+++ b/app/src/main/java/com/redcoracle/episodes/tvdb/Client.java
@@ -26,7 +26,6 @@ import com.uwetrottmann.thetvdb.entities.SeriesResponse;
 import com.uwetrottmann.thetvdb.entities.SeriesResultsResponse;
 
 import java.io.IOException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -44,9 +43,8 @@ public class Client
 	public List<Show> searchShows(String query, String language) {
 
 		try {
-			final String escapedQuery = URLEncoder.encode(query, "UTF-8");
 			final retrofit2.Response<SeriesResultsResponse> response =
-					tvdb.search().series(escapedQuery, null, null, null, language).execute();
+					tvdb.search().series(query, null, null, null, language).execute();
 			if (response.isSuccessful()) {
 				final SearchShowsParser parser = new SearchShowsParser();
 				return parser.parse(response, language);


### PR DESCRIPTION
Fixes empty search results list for queries like "Great Pretender".

The additional call to `URLEncoder.encode` led to a faulty space encoding and a 404 response
```
Response{protocol=h2, code=404, message=, url=https://api.thetvdb.com/search/series?name=great%2Bpretender}
```

The thetvdb wrapper seems to be taking care of the encoding, though. The same search query as above returns
```
Response{protocol=h2, code=200, message=, url=https://api.thetvdb.com/search/series?name=great%20pretender}
```
with the suggested change.

Querying the Japanese translation also seems to be working fine and returns the right result.
```
Response{protocol=h2, code=200, message=, url=https://api.thetvdb.com/search/series?name=%E3%82%B0%E3%83%AC%E3%83%BC%E3%83%88%E3%83%97%E3%83%AA%E3%83%86%E3%83%B3%E3%83%80%E3%83%BC}
```