### PR TITLE
Fix back button on season details

### DIFF
--- a/app/src/main/java/com/redcoracle/episodes/SeasonActivity.java
+++ b/app/src/main/java/com/redcoracle/episodes/SeasonActivity.java
@@ -136,7 +136,7 @@ public class SeasonActivity
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
 		int item_id = item.getItemId();
-		if (item_id == R.id.home) {
+		if (item_id == android.R.id.home) {
 			finish();
 			return true;
 		} else if (item_id == R.id.menu_mark_season_watched) {


### PR DESCRIPTION
Fixes the back button in the navbar when viewing the list of episodes in a season.

Closes #66