### PR TITLE
Version 0.15.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 33
-        versionCode 22
-        versionName "0.15.0"
+        versionCode 23
+        versionName "0.15.1"
         buildConfigField "String", "TVDB_KEY", "\"E457AE7B767BC9F4\""
         buildConfigField "String", "GIT_COMMIT_ID", "\"${getCommitId()}\""
     }

--- a/fastlane/metadata/android/en-US/changelogs/0023.txt
+++ b/fastlane/metadata/android/en-US/changelogs/0023.txt
@@ -1,0 +1,4 @@
+- Target version 33 (Android 13)
+- Raise minimum version to 21 (Android L)
+- Request notification permission on Android 13+
+- Update gradle version

--- a/fastlane/metadata/android/en-US/changelogs/0023.txt
+++ b/fastlane/metadata/android/en-US/changelogs/0023.txt
@@ -1,3 +1,4 @@
+- Final release with TVDB as metadata provider
 - Target version 33 (Android 13)
 - Raise minimum version to 21 (Android L)
 - Request notification permission on Android 13+


### PR DESCRIPTION
- Final release with TVDB as metadata provider
- Target version 33 (Android 13)
- Raise minimum version to 21 (Android L)
- Request notification permission on Android 13+
- Update gradle version