### PR TITLE
Adjust border and size of star and archive icons

### DIFF
--- a/app/src/main/res/drawable/ic_show_archived.xml
+++ b/app/src/main/res/drawable/ic_show_archived.xml
@@ -4,6 +4,8 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#FFFFFF"
+        android:strokeColor="@android:color/black"
+        android:strokeWidth="0.5"
+        android:fillColor="@android:color/white"
         android:pathData="M20.55,5.22l-1.39,-1.68C18.88,3.21 18.47,3 18,3H6C5.53,3 5.12,3.21 4.85,3.55L3.46,5.22C3.17,5.57 3,6.01 3,6.5V19c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V6.5C21,6.01 20.83,5.57 20.55,5.22zM12,9.5l5.5,5.5H14v2h-4v-2H6.5L12,9.5zM5.12,5l0.82,-1h12l0.93,1H5.12z" />
 </vector>

--- a/app/src/main/res/drawable/ic_show_starred.xml
+++ b/app/src/main/res/drawable/ic_show_starred.xml
@@ -4,6 +4,8 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#FFFFFF"
+        android:strokeColor="@android:color/black"
+        android:strokeWidth="0.5"
+        android:fillColor="@android:color/white"
         android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z" />
 </vector>

--- a/app/src/main/res/drawable/ic_show_unarchived.xml
+++ b/app/src/main/res/drawable/ic_show_unarchived.xml
@@ -4,6 +4,8 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#FFFFFF"
+        android:strokeColor="@android:color/black"
+        android:strokeWidth="0.5"
+        android:fillColor="@android:color/white"
         android:pathData="M20.54,5.23l-1.39,-1.68C18.88,3.21 18.47,3 18,3H6c-0.47,0 -0.88,0.21 -1.16,0.55L3.46,5.23C3.17,5.57 3,6.02 3,6.5V19c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V6.5c0,-0.48 -0.17,-0.93 -0.46,-1.27zM12,17.5L6.5,12H10v-2h4v2h3.5L12,17.5zM5.12,5l0.81,-1h12l0.94,1H5.12z" />
 </vector>

--- a/app/src/main/res/drawable/ic_show_unstarred.xml
+++ b/app/src/main/res/drawable/ic_show_unstarred.xml
@@ -4,6 +4,8 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#FFFFFF"
+        android:strokeColor="@android:color/black"
+        android:strokeWidth="0.5"
+        android:fillColor="@android:color/white"
         android:pathData="M22,9.24l-7.19,-0.62L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21 12,17.27 18.18,21l-1.63,-7.03L22,9.24zM12,15.4l-3.76,2.27 1,-4.28 -3.32,-2.88 4.38,-0.38L12,6.1l1.71,4.04 4.38,0.38 -3.32,2.88 1,4.28L12,15.4z" />
 </vector>

--- a/app/src/main/res/layout/shows_list_item.xml
+++ b/app/src/main/res/layout/shows_list_item.xml
@@ -36,8 +36,8 @@
   </FrameLayout>
   <ToggleButton
       android:id="@+id/show_starred_toggle"
-      android:layout_width="32dp"
-      android:layout_height="32dp"
+      android:layout_width="28dp"
+      android:layout_height="28dp"
       android:textOn=""
       android:textOff=""
       android:background="@drawable/starred_toggle"
@@ -46,8 +46,8 @@
       android:layout_alignParentRight="true" />
   <ToggleButton
       android:id="@+id/show_archived_toggle"
-      android:layout_width="32dp"
-      android:layout_height="32dp"
+      android:layout_width="28dp"
+      android:layout_height="28dp"
       android:layout_marginRight="32dp"
       android:textOn=""
       android:textOff=""


### PR DESCRIPTION
There were some suggestions regarding the size and shape of icons in #106 that were not included in the pull request because I was waiting for the final opinion. They are included in this pull request if they are still needed. This PR sets the size to 28dp and adds a border around the icons, as shown [here](https://github.com/red-coracle/episodes/pull/106#issuecomment-1972506556).